### PR TITLE
fix: incorrect proto name where javapackage or protopackage is empty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group 'com.gojek'
-version '4.2.0'
+version '4.2.1'
 
 dependencies {
     compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'

--- a/src/main/java/com/gojek/de/stencil/DescriptorMapBuilder.java
+++ b/src/main/java/com/gojek/de/stencil/DescriptorMapBuilder.java
@@ -35,11 +35,13 @@ public class DescriptorMapBuilder {
 
     private Map<String, DescriptorAndTypeName> getFlattenedDescriptors(Descriptors.Descriptor descriptor, String javaPackage, String protoPackage, String parentClassName, Map<String, DescriptorAndTypeName> initialDescriptorMap) {
         String className = getClassName(descriptor, parentClassName);
+        String javaClassName = javaPackage.isEmpty() ? className : String.format("%s.%s", javaPackage, className);
+        String typeName = protoPackage.isEmpty() ? String.format(".%s", className) : String.format(".%s.%s", protoPackage, className);
         initialDescriptorMap.put(
-                String.format("%s.%s", javaPackage, className),
+                javaClassName,
                 new DescriptorAndTypeName(
                         descriptor,
-                        String.format(".%s.%s", protoPackage, className)
+                        typeName
                 ));
         descriptor.getNestedTypes()
                 .forEach(desc -> getFlattenedDescriptors(desc, javaPackage, protoPackage, className, initialDescriptorMap));

--- a/src/test/java/com/gojek/de/stencil/DescriptorMapBuilderTest.java
+++ b/src/test/java/com/gojek/de/stencil/DescriptorMapBuilderTest.java
@@ -57,4 +57,15 @@ public class DescriptorMapBuilderTest {
         assertNotNull(RECORD.getDescriptor().findFieldByName("record"));
     }
 
+    @Test
+    public void TestDescriptorsWithoutPackageName() throws IOException, Descriptors.DescriptorValidationException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String descriptorFilePath = "__files/descriptors.bin";
+        InputStream fileInputStream = new FileInputStream(Objects.requireNonNull(classLoader.getResource(descriptorFilePath)).getFile());
+        Map<String, DescriptorAndTypeName> descriptorMap = new DescriptorMapBuilder().buildFrom(fileInputStream);
+
+        final DescriptorAndTypeName protoWithoutPackage = descriptorMap.get("com.gojek.stencil.RootField");
+        assertEquals(".RootField", protoWithoutPackage.getTypeName());
+    }
+
 }

--- a/src/test/proto/ProtoWithoutPackage.proto
+++ b/src/test/proto/ProtoWithoutPackage.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+option java_package = "com.gojek.stencil";
+option java_multiple_files = true;
+option java_outer_classname = "ProtoWithoutPackage";
+
+message RootField {
+    string string_field = 1;
+    NestedField nested_field = 2;
+    uint32 int_field = 3;
+}
+
+message NestedField {
+    string string_field = 1;
+    uint32 int_field = 2;
+}


### PR DESCRIPTION
DescriptorMap contains incorrect protoname in case that protopackage or javapackage is empty string.

For example:
If protopackage is empty string, typename becomes `..ProtoMessage` when it should be `.ProtoMessage` because we are constructing it as `String.format(".%s.%s", protoPackage, className)`

In this fix, we are not using double dots in case that protopackage is empty string.