### PR TITLE
feat: search command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(ServerCommand())
 	cmd.AddCommand(NamespaceCmd())
 	cmd.AddCommand(SchemaCmd())
+	cmd.AddCommand(SearchCmd())
 
 	// Help topics
 	cmdx.SetHelp(cmd)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -25,6 +25,7 @@ func SearchCmd() *cobra.Command {
 		Aliases: []string{"search"},
 		Short:   "Search",
 		Long:    "Search your queries on schemas",
+		Args:    cobra.ExactArgs(1),
 		Example: heredoc.Doc(`
 			$ stencil search <query> --namespace=<namespace> --schema=<schema> --version=<version> --history=<history>
 		`),

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -78,7 +78,7 @@ func SearchCmd() *cobra.Command {
 			report = append(report, []string{"INDEX", "NAMESPACE", "SCHEMA", "FIELDS", "TYPES", "VERSION"})
 			for i, h := range hits {
 				report = append(report, []string{
-					strconv.Itoa(int(i) + 1),
+					strconv.Itoa(i + 1),
 					h.GetNamespaceId(),
 					h.GetSchemaId(),
 					strings.Join(h.GetFields(), ","),

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -76,15 +76,15 @@ func SearchCmd() *cobra.Command {
 
 			fmt.Printf(" \nShowing %d versions \n", len(hits))
 
-			report = append(report, []string{"NAMESPACE", "SCHEMA", "VERSION", "TYPES", "FIELDS"})
+			report = append(report, []string{"TYPES", "NAMESPACE", "SCHEMA", "VERSION", "FIELDS"})
 			for _, h := range hits {
 				m := groupByType(h.GetFields())
 				for t, f := range m {
 					report = append(report, []string{
+						t,
 						h.GetNamespaceId(),
 						h.GetSchemaId(),
 						strconv.Itoa(int(h.GetVersionId())),
-						t,
 						strings.Join(f, ", "),
 					})
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/odpf/salt/printer"
+	stencilv1beta1 "github.com/odpf/stencil/server/odpf/stencil/v1beta1"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+)
+
+func SearchCmd() *cobra.Command {
+	var host, namespaceID, schemaID string
+	var versionID int32
+	var history bool
+	var req stencilv1beta1.SearchRequest
+
+	cmd := &cobra.Command{
+		Use:     "search",
+		Aliases: []string{"search"},
+		Short:   "Search",
+		Long:    "Search your queries on schemas",
+		Example: heredoc.Doc(`
+			$ stencil search <query> --namespace=<namespace> --schema=<schema> --version=<version> --history=<history>
+		`),
+		Annotations: map[string]string{
+			"group:core": "true",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			s := printer.Spin("")
+			defer s.Stop()
+
+			conn, err := grpc.Dial(host, grpc.WithInsecure())
+			if err != nil {
+				return err
+			}
+			defer conn.Close()
+
+			query := args[0]
+			req.Query = query
+			req.NamespaceId = namespaceID
+			req.SchemaId = schemaID
+
+			if versionID != 0 {
+				req.Version = &stencilv1beta1.SearchRequest_VersionId{
+					VersionId: versionID,
+				}
+			} else if history {
+				req.Version = &stencilv1beta1.SearchRequest_History{
+					History: history,
+				}
+			}
+
+			client := stencilv1beta1.NewStencilServiceClient(conn)
+			res, err := client.Search(context.Background(), &req)
+			if err != nil {
+				return err
+			}
+
+			hits := res.GetHits()
+			meta := res.GetMeta()
+
+			report := [][]string{}
+			s.Stop()
+
+			if len(hits) == 0 {
+				fmt.Printf("No results found")
+				return nil
+			}
+
+			fmt.Printf(" \nShowing %d result(s) \n", len(hits))
+
+			report = append(report, []string{"INDEX", "NAMESPACE", "SCHEMA", "FIELDS", "TYPES", "VERSION"})
+			for i, h := range hits {
+				report = append(report, []string{
+					strconv.Itoa(int(i) + 1),
+					h.GetNamespaceId(),
+					h.GetSchemaId(),
+					strings.Join(h.GetFields(), ","),
+					strings.Join(h.GetTypes(), ","),
+					strconv.Itoa(int(h.GetVersionId())),
+				})
+			}
+			printer.Table(os.Stdout, report)
+
+			report = [][]string{}
+			report = append(report, []string{"\nTOTAL"})
+			report = append(report, []string{strconv.Itoa(int(meta.GetTotal()))})
+			printer.Table(os.Stdout, report)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&host, "host", "", "stencil host address eg: localhost:8000")
+	cmd.MarkFlagRequired("host")
+	cmd.Flags().StringVarP(&namespaceID, "namespace", "n", "", "parent namespace ID")
+	cmd.MarkFlagRequired("namespace")
+	cmd.Flags().StringVarP(&schemaID, "schema", "s", "", "related schema ID")
+	cmd.MarkFlagRequired("schema")
+	cmd.Flags().Int32VarP(&versionID, "version", "v", 0, "version of the schema")
+	cmd.Flags().BoolVarP(&history, "history", "h", false, "set this to enable history")
+
+	return cmd
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -44,6 +44,12 @@ func SearchCmd() *cobra.Command {
 
 			query := args[0]
 			req.Query = query
+
+			if len(schemaID) > 0 && len(namespaceID) == 0 {
+				s.Stop()
+				fmt.Println("Namespace ID not specified for", schemaID)
+				return nil
+			}
 			req.NamespaceId = namespaceID
 			req.SchemaId = schemaID
 
@@ -74,7 +80,7 @@ func SearchCmd() *cobra.Command {
 				return nil
 			}
 
-			fmt.Printf(" \nShowing %d versions \n", len(hits))
+			fmt.Printf(" \nFound results across %d schema(s)/version(s) \n\n", len(hits))
 
 			report = append(report, []string{"TYPES", "NAMESPACE", "SCHEMA", "VERSION", "FIELDS"})
 			for _, h := range hits {
@@ -103,9 +109,7 @@ func SearchCmd() *cobra.Command {
 	cmd.Flags().StringVar(&host, "host", "", "stencil host address eg: localhost:8000")
 	cmd.MarkFlagRequired("host")
 	cmd.Flags().StringVarP(&namespaceID, "namespace", "n", "", "parent namespace ID")
-	cmd.MarkFlagRequired("namespace")
 	cmd.Flags().StringVarP(&schemaID, "schema", "s", "", "related schema ID")
-	cmd.MarkFlagRequired("schema")
 	cmd.Flags().Int32VarP(&versionID, "version", "v", 0, "version of the schema")
 	cmd.Flags().BoolVarP(&history, "history", "h", false, "set this to enable history")
 


### PR DESCRIPTION
Command:
`$ stencil search <query> --namespace=<namespace> --schema=<schema> --version=<version> --history=<history>`

Set either of `version` or `history` flags. Version flag is used to search on a particular version while history flag enables the user to search across all the versions.

