### PR TITLE
chore: move search and namespace domain to search package

### DIFF
--- a/core/namespace/namespace.go
+++ b/core/namespace/namespace.go
@@ -1,4 +1,4 @@
-package domain
+package namespace
 
 import (
 	"context"

--- a/core/namespace/service.go
+++ b/core/namespace/service.go
@@ -2,19 +2,17 @@ package namespace
 
 import (
 	"context"
-
-	"github.com/odpf/stencil/domain"
 )
 
 type Service struct {
-	Repo domain.NamespaceRepository
+	Repo NamespaceRepository
 }
 
-func (s Service) Create(ctx context.Context, ns domain.Namespace) (domain.Namespace, error) {
+func (s Service) Create(ctx context.Context, ns Namespace) (Namespace, error) {
 	return s.Repo.CreateNamespace(ctx, ns)
 }
 
-func (s Service) Update(ctx context.Context, ns domain.Namespace) (domain.Namespace, error) {
+func (s Service) Update(ctx context.Context, ns Namespace) (Namespace, error) {
 	return s.Repo.UpdateNamespace(ctx, ns)
 }
 
@@ -22,7 +20,7 @@ func (s Service) List(ctx context.Context) ([]string, error) {
 	return s.Repo.ListNamespaces(ctx)
 }
 
-func (s Service) Get(ctx context.Context, name string) (domain.Namespace, error) {
+func (s Service) Get(ctx context.Context, name string) (Namespace, error) {
 	return s.Repo.GetNamespace(ctx, name)
 }
 

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/odpf/stencil/core/namespace"
 	"github.com/odpf/stencil/domain"
 	"github.com/odpf/stencil/internal/store"
 )
@@ -28,7 +29,7 @@ func getBytes(key interface{}) []byte {
 	return buf
 }
 
-func NewService(repo domain.SchemaRepository, provider SchemaProvider, nsSvc domain.NamespaceService, cache schemaCache) *Service {
+func NewService(repo domain.SchemaRepository, provider SchemaProvider, nsSvc namespace.NamespaceService, cache schemaCache) *Service {
 	return &Service{
 		Repo:           repo,
 		SchemaProvider: provider,
@@ -45,7 +46,7 @@ type schemaCache interface {
 type Service struct {
 	SchemaProvider SchemaProvider
 	Repo           domain.SchemaRepository
-	NamespaceSvc   domain.NamespaceService
+	NamespaceSvc   namespace.NamespaceService
 	cache          schemaCache
 }
 

--- a/core/schema/service_test.go
+++ b/core/schema/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/odpf/stencil/core/namespace"
 	"github.com/odpf/stencil/core/schema"
 	"github.com/odpf/stencil/domain"
 	"github.com/odpf/stencil/internal/store"
@@ -30,7 +31,7 @@ func TestSchemaCreate(t *testing.T) {
 	t.Run("should return error if namespace not found", func(t *testing.T) {
 		svc, nsService, _, _ := getSvc()
 		nsName := "testNamespace"
-		nsService.On("Get", mock.Anything, nsName).Return(domain.Namespace{}, store.NoRowsErr)
+		nsService.On("Get", mock.Anything, nsName).Return(namespace.Namespace{}, store.NoRowsErr)
 		_, err := svc.Create(ctx, nsName, "a", &domain.Metadata{}, []byte(""))
 		assert.NotNil(t, err)
 		assert.ErrorIs(t, err, store.NoRowsErr)
@@ -41,7 +42,7 @@ func TestSchemaCreate(t *testing.T) {
 		svc, nsService, schemaProvider, _ := getSvc()
 		nsName := "testNamespace"
 		data := []byte("data")
-		nsService.On("Get", mock.Anything, nsName).Return(domain.Namespace{Format: "avro"}, nil)
+		nsService.On("Get", mock.Anything, nsName).Return(namespace.Namespace{Format: "avro"}, nil)
 		schemaProvider.On("ParseSchema", "protobuf", data).Return(&mocks.ParsedSchema{}, errors.New("invalid schema"))
 		_, err := svc.Create(ctx, nsName, "a", &domain.Metadata{Format: "protobuf"}, data)
 		assert.NotNil(t, err)
@@ -52,7 +53,7 @@ func TestSchemaCreate(t *testing.T) {
 		svc, nsService, schemaProvider, _ := getSvc()
 		nsName := "testNamespace"
 		data := []byte("data")
-		nsService.On("Get", mock.Anything, nsName).Return(domain.Namespace{Format: "protobuf"}, nil)
+		nsService.On("Get", mock.Anything, nsName).Return(namespace.Namespace{Format: "protobuf"}, nil)
 		schemaProvider.On("ParseSchema", "protobuf", data).Return(&mocks.ParsedSchema{}, errors.New("invalid schema"))
 		_, err := svc.Create(ctx, nsName, "a", &domain.Metadata{}, data)
 		assert.NotNil(t, err)
@@ -65,7 +66,7 @@ func TestSchemaCreate(t *testing.T) {
 		parsedSchema := &mocks.ParsedSchema{}
 		nsName := "testNamespace"
 		data := []byte("data")
-		nsService.On("Get", mock.Anything, nsName).Return(domain.Namespace{Format: "protobuf"}, nil)
+		nsService.On("Get", mock.Anything, nsName).Return(namespace.Namespace{Format: "protobuf"}, nil)
 		schemaProvider.On("ParseSchema", "protobuf", data).Return(parsedSchema, nil)
 		schemaRepo.On("GetLatestVersion", mock.Anything, nsName, "a").Return(int32(2), store.NoRowsErr)
 		parsedSchema.On("GetCanonicalValue").Return(scFile)
@@ -81,7 +82,7 @@ func TestSchemaCreate(t *testing.T) {
 		parsedSchema := &mocks.ParsedSchema{}
 		nsName := "testNamespace"
 		data := []byte("data")
-		nsService.On("Get", mock.Anything, nsName).Return(domain.Namespace{Format: "protobuf"}, nil)
+		nsService.On("Get", mock.Anything, nsName).Return(namespace.Namespace{Format: "protobuf"}, nil)
 		schemaProvider.On("ParseSchema", "protobuf", data).Return(parsedSchema, nil)
 		schemaRepo.On("GetLatestVersion", mock.Anything, nsName, "a").Return(int32(2), errors.New("some other error apart from noRowsError"))
 		_, err := svc.Create(ctx, nsName, "a", &domain.Metadata{}, data)
@@ -96,7 +97,7 @@ func TestSchemaCreate(t *testing.T) {
 		nsName := "testNamespace"
 		data := []byte("data aa")
 		prevData := []byte("some prev data")
-		nsService.On("Get", mock.Anything, nsName).Return(domain.Namespace{Format: "protobuf", Compatibility: "COMPATIBILITY_BACKWARD"}, nil)
+		nsService.On("Get", mock.Anything, nsName).Return(namespace.Namespace{Format: "protobuf", Compatibility: "COMPATIBILITY_BACKWARD"}, nil)
 		schemaProvider.On("ParseSchema", "protobuf", data).Return(parsedSchema, nil).Once()
 		schemaRepo.On("GetSchemaMetadata", mock.Anything, nsName, "a").Return(&domain.Metadata{Format: "protobuf"}, nil)
 		schemaRepo.On("GetLatestVersion", mock.Anything, nsName, "a").Return(int32(3), nil)
@@ -130,7 +131,7 @@ func TestSchemaCreate(t *testing.T) {
 				if test.isError {
 					compErr = errors.New("compatibilit error")
 				}
-				nsService.On("Get", mock.Anything, nsName).Return(domain.Namespace{Format: "protobuf", Compatibility: "COMPATIBILITY_BACKWARD"}, nil)
+				nsService.On("Get", mock.Anything, nsName).Return(namespace.Namespace{Format: "protobuf", Compatibility: "COMPATIBILITY_BACKWARD"}, nil)
 				schemaProvider.On("ParseSchema", "protobuf", data).Return(parsedSchema, nil).Once()
 				schemaRepo.On("GetSchemaMetadata", mock.Anything, nsName, "a").Return(&domain.Metadata{Format: "protobuf"}, nil)
 				schemaRepo.On("GetLatestVersion", mock.Anything, nsName, "a").Return(int32(3), nil)

--- a/core/search/search.go
+++ b/core/search/search.go
@@ -1,4 +1,4 @@
-package domain
+package search
 
 import "context"
 

--- a/core/search/service.go
+++ b/core/search/service.go
@@ -3,8 +3,6 @@ package search
 import (
 	"context"
 	"errors"
-
-	"github.com/odpf/stencil/domain"
 )
 
 var (
@@ -14,10 +12,10 @@ var (
 )
 
 type Service struct {
-	Repo domain.SearchRepository
+	Repo SearchRepository
 }
 
-func (s *Service) Search(ctx context.Context, req *domain.SearchRequest) (*domain.SearchResponse, error) {
+func (s *Service) Search(ctx context.Context, req *SearchRequest) (*SearchResponse, error) {
 	if req.Query == "" {
 		return nil, ErrEmptyQueryString
 	}
@@ -26,7 +24,7 @@ func (s *Service) Search(ctx context.Context, req *domain.SearchRequest) (*domai
 		return nil, ErrEmptyNamespaceID
 	}
 
-	var res []*domain.SearchHits
+	var res []*SearchHits
 	var err error
 	if req.VersionID == 0 && !req.History {
 		res, err = s.Repo.SearchLatest(ctx, req)
@@ -40,7 +38,7 @@ func (s *Service) Search(ctx context.Context, req *domain.SearchRequest) (*domai
 	if err != nil {
 		return nil, err
 	}
-	return &domain.SearchResponse{
+	return &SearchResponse{
 		Hits: res,
 	}, nil
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/odpf/stencil/core/search"
 	"github.com/odpf/stencil/domain"
 	stencilv1beta1 "github.com/odpf/stencil/proto/odpf/stencil/v1beta1"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -21,10 +22,10 @@ type API struct {
 	grpc_health_v1.UnimplementedHealthServer
 	namespace domain.NamespaceService
 	schema    domain.SchemaService
-	search    domain.SearchService
+	search    search.SearchService
 }
 
-func NewAPI(namespace domain.NamespaceService, schema domain.SchemaService, search domain.SearchService) *API {
+func NewAPI(namespace domain.NamespaceService, schema domain.SchemaService, search search.SearchService) *API {
 	return &API{
 		namespace: namespace,
 		schema:    schema,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/odpf/stencil/core/namespace"
 	"github.com/odpf/stencil/core/search"
 	"github.com/odpf/stencil/domain"
 	stencilv1beta1 "github.com/odpf/stencil/proto/odpf/stencil/v1beta1"
@@ -20,12 +21,12 @@ type errHandleFunc func(http.ResponseWriter, *http.Request, map[string]string) e
 type API struct {
 	stencilv1beta1.UnimplementedStencilServiceServer
 	grpc_health_v1.UnimplementedHealthServer
-	namespace domain.NamespaceService
+	namespace namespace.NamespaceService
 	schema    domain.SchemaService
 	search    search.SearchService
 }
 
-func NewAPI(namespace domain.NamespaceService, schema domain.SchemaService, search search.SearchService) *API {
+func NewAPI(namespace namespace.NamespaceService, schema domain.SchemaService, search search.SearchService) *API {
 	return &API{
 		namespace: namespace,
 		schema:    schema,

--- a/internal/api/namespace.go
+++ b/internal/api/namespace.go
@@ -3,13 +3,13 @@ package api
 import (
 	"context"
 
-	"github.com/odpf/stencil/domain"
+	"github.com/odpf/stencil/core/namespace"
 	stencilv1beta1 "github.com/odpf/stencil/proto/odpf/stencil/v1beta1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func createNamespaceRequestToNamespace(r *stencilv1beta1.CreateNamespaceRequest) domain.Namespace {
-	return domain.Namespace{
+func createNamespaceRequestToNamespace(r *stencilv1beta1.CreateNamespaceRequest) namespace.Namespace {
+	return namespace.Namespace{
 		ID:            r.GetId(),
 		Format:        r.GetFormat().String(),
 		Compatibility: r.GetCompatibility().String(),
@@ -17,7 +17,7 @@ func createNamespaceRequestToNamespace(r *stencilv1beta1.CreateNamespaceRequest)
 	}
 }
 
-func namespaceToProto(ns domain.Namespace) *stencilv1beta1.Namespace {
+func namespaceToProto(ns namespace.Namespace) *stencilv1beta1.Namespace {
 	return &stencilv1beta1.Namespace{
 		Id:            ns.ID,
 		Format:        stencilv1beta1.Schema_Format(stencilv1beta1.Schema_Format_value[ns.Format]),
@@ -36,7 +36,7 @@ func (a *API) CreateNamespace(ctx context.Context, in *stencilv1beta1.CreateName
 }
 
 func (a *API) UpdateNamespace(ctx context.Context, in *stencilv1beta1.UpdateNamespaceRequest) (*stencilv1beta1.UpdateNamespaceResponse, error) {
-	ns, err := a.namespace.Update(ctx, domain.Namespace{ID: in.GetId(), Format: in.GetFormat().String(), Compatibility: in.GetCompatibility().String(), Description: in.GetDescription()})
+	ns, err := a.namespace.Update(ctx, namespace.Namespace{ID: in.GetId(), Format: in.GetFormat().String(), Compatibility: in.GetCompatibility().String(), Description: in.GetDescription()})
 	return &stencilv1beta1.UpdateNamespaceResponse{Namespace: namespaceToProto(ns)}, err
 }
 

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/odpf/stencil/domain"
+	"github.com/odpf/stencil/core/search"
 	stencilv1beta1 "github.com/odpf/stencil/proto/odpf/stencil/v1beta1"
 )
 
 func (a *API) Search(ctx context.Context, in *stencilv1beta1.SearchRequest) (*stencilv1beta1.SearchResponse, error) {
-	searchReq := &domain.SearchRequest{
+	searchReq := &search.SearchRequest{
 		NamespaceID: in.GetNamespaceId(),
 		Query:       in.GetQuery(),
 		SchemaID:    in.GetSchemaId(),

--- a/internal/store/postgres/repository.go
+++ b/internal/store/postgres/repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/georgysavva/scany/pgxscan"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
+	"github.com/odpf/stencil/core/namespace"
 	"github.com/odpf/stencil/core/search"
 	"github.com/odpf/stencil/domain"
 	"github.com/odpf/stencil/internal/store"
@@ -43,20 +44,20 @@ func (r *Store) Close() {
 	r.db.Close()
 }
 
-func (r *Store) CreateNamespace(ctx context.Context, ns domain.Namespace) (domain.Namespace, error) {
-	newNamespace := domain.Namespace{}
+func (r *Store) CreateNamespace(ctx context.Context, ns namespace.Namespace) (namespace.Namespace, error) {
+	newNamespace := namespace.Namespace{}
 	err := pgxscan.Get(ctx, r.db, &newNamespace, namespaceInsertQuery, ns.ID, ns.Format, ns.Compatibility, ns.Description)
 	return newNamespace, wrapError(err, ns.ID)
 }
 
-func (r *Store) UpdateNamespace(ctx context.Context, ns domain.Namespace) (domain.Namespace, error) {
-	newNamespace := domain.Namespace{}
+func (r *Store) UpdateNamespace(ctx context.Context, ns namespace.Namespace) (namespace.Namespace, error) {
+	newNamespace := namespace.Namespace{}
 	err := pgxscan.Get(ctx, r.db, &newNamespace, namespaceUpdateQuery, ns.ID, ns.Format, ns.Compatibility, ns.Description)
 	return newNamespace, wrapError(err, ns.ID)
 }
 
-func (r *Store) GetNamespace(ctx context.Context, id string) (domain.Namespace, error) {
-	newNamespace := domain.Namespace{}
+func (r *Store) GetNamespace(ctx context.Context, id string) (namespace.Namespace, error) {
+	newNamespace := namespace.Namespace{}
 	err := pgxscan.Get(ctx, r.db, &newNamespace, namespaceGetQuery, id)
 	return newNamespace, wrapError(err, id)
 }

--- a/internal/store/postgres/repository.go
+++ b/internal/store/postgres/repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/georgysavva/scany/pgxscan"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
+	"github.com/odpf/stencil/core/search"
 	"github.com/odpf/stencil/domain"
 	"github.com/odpf/stencil/internal/store"
 )
@@ -151,14 +152,14 @@ func (r *Store) DeleteVersion(ctx context.Context, ns string, sc string, version
 	return wrapError(err, "delete version")
 }
 
-func (r *Store) Search(ctx context.Context, req *domain.SearchRequest) ([]*domain.SearchHits, error) {
-	var searchHits []*domain.SearchHits
+func (r *Store) Search(ctx context.Context, req *search.SearchRequest) ([]*search.SearchHits, error) {
+	var searchHits []*search.SearchHits
 	err := pgxscan.Select(ctx, r.db, &searchHits, searchAllQuery, req.NamespaceID, req.SchemaID, req.VersionID, req.Query)
 	return searchHits, err
 }
 
-func (r *Store) SearchLatest(ctx context.Context, req *domain.SearchRequest) ([]*domain.SearchHits, error) {
-	var searchHits []*domain.SearchHits
+func (r *Store) SearchLatest(ctx context.Context, req *search.SearchRequest) ([]*search.SearchHits, error) {
+	var searchHits []*search.SearchHits
 	err := pgxscan.Select(ctx, r.db, &searchHits, searchLatestQuery, req.NamespaceID, req.SchemaID, req.Query)
 	return searchHits, err
 }

--- a/internal/store/postgres/repository_test.go
+++ b/internal/store/postgres/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/odpf/stencil/core/namespace"
 	"github.com/odpf/stencil/domain"
 	"github.com/odpf/stencil/internal/store"
 	"github.com/odpf/stencil/internal/store/postgres"
@@ -36,7 +37,7 @@ func tearDown(t *testing.T) {
 	}
 }
 
-func assertNamespace(t *testing.T, expected, actual domain.Namespace) {
+func assertNamespace(t *testing.T, expected, actual namespace.Namespace) {
 	t.Helper()
 	assert.Equal(t, expected.ID, actual.ID)
 	assert.Equal(t, expected.Compatibility, actual.Compatibility)
@@ -50,7 +51,7 @@ func TestStorage(t *testing.T) {
 	tearDown(t)
 	db := getStore(t)
 	ctx := context.Background()
-	n := &domain.Namespace{ID: "test", Format: "protobuf", Compatibility: "FULL", Description: "testDesc"}
+	n := &namespace.Namespace{ID: "test", Format: "protobuf", Compatibility: "FULL", Description: "testDesc"}
 	t.Run("Namespace", func(t *testing.T) {
 		t.Run("create: should create namespace", func(t *testing.T) {
 			ns, err := db.CreateNamespace(ctx, *n)
@@ -95,7 +96,7 @@ func TestStorage(t *testing.T) {
 	})
 
 	t.Run("schema", func(t *testing.T) {
-		n := &domain.Namespace{ID: "testschema", Format: "protobuf", Compatibility: "FULL", Description: "testDesc"}
+		n := &namespace.Namespace{ID: "testschema", Format: "protobuf", Compatibility: "FULL", Description: "testDesc"}
 		_, err := db.CreateNamespace(ctx, *n)
 		assert.Nil(t, err)
 		meta := &domain.Metadata{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,11 +1,12 @@
 package store
 
 import (
+	"github.com/odpf/stencil/core/namespace"
 	"github.com/odpf/stencil/domain"
 )
 
 // Store is the interface that all database objects must implement.
 type Store interface {
-	domain.NamespaceRepository
+	namespace.NamespaceRepository
 	domain.SchemaRepository
 }

--- a/mocks/NamespaceRepository.go
+++ b/mocks/NamespaceRepository.go
@@ -5,7 +5,7 @@ package mocks
 import (
 	context "context"
 
-	domain "github.com/odpf/stencil/domain"
+	namespace "github.com/odpf/stencil/core/namespace"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -15,18 +15,18 @@ type NamespaceRepository struct {
 }
 
 // CreateNamespace provides a mock function with given fields: _a0, _a1
-func (_m *NamespaceRepository) CreateNamespace(_a0 context.Context, _a1 domain.Namespace) (domain.Namespace, error) {
+func (_m *NamespaceRepository) CreateNamespace(_a0 context.Context, _a1 namespace.Namespace) (namespace.Namespace, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 domain.Namespace
-	if rf, ok := ret.Get(0).(func(context.Context, domain.Namespace) domain.Namespace); ok {
+	var r0 namespace.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, namespace.Namespace) namespace.Namespace); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		r0 = ret.Get(0).(domain.Namespace)
+		r0 = ret.Get(0).(namespace.Namespace)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, domain.Namespace) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, namespace.Namespace) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
@@ -50,14 +50,14 @@ func (_m *NamespaceRepository) DeleteNamespace(_a0 context.Context, _a1 string) 
 }
 
 // GetNamespace provides a mock function with given fields: _a0, _a1
-func (_m *NamespaceRepository) GetNamespace(_a0 context.Context, _a1 string) (domain.Namespace, error) {
+func (_m *NamespaceRepository) GetNamespace(_a0 context.Context, _a1 string) (namespace.Namespace, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 domain.Namespace
-	if rf, ok := ret.Get(0).(func(context.Context, string) domain.Namespace); ok {
+	var r0 namespace.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, string) namespace.Namespace); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		r0 = ret.Get(0).(domain.Namespace)
+		r0 = ret.Get(0).(namespace.Namespace)
 	}
 
 	var r1 error
@@ -94,18 +94,18 @@ func (_m *NamespaceRepository) ListNamespaces(_a0 context.Context) ([]string, er
 }
 
 // UpdateNamespace provides a mock function with given fields: _a0, _a1
-func (_m *NamespaceRepository) UpdateNamespace(_a0 context.Context, _a1 domain.Namespace) (domain.Namespace, error) {
+func (_m *NamespaceRepository) UpdateNamespace(_a0 context.Context, _a1 namespace.Namespace) (namespace.Namespace, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 domain.Namespace
-	if rf, ok := ret.Get(0).(func(context.Context, domain.Namespace) domain.Namespace); ok {
+	var r0 namespace.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, namespace.Namespace) namespace.Namespace); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		r0 = ret.Get(0).(domain.Namespace)
+		r0 = ret.Get(0).(namespace.Namespace)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, domain.Namespace) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, namespace.Namespace) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)

--- a/mocks/NamespaceService.go
+++ b/mocks/NamespaceService.go
@@ -5,7 +5,7 @@ package mocks
 import (
 	context "context"
 
-	domain "github.com/odpf/stencil/domain"
+	namespace "github.com/odpf/stencil/core/namespace"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -15,18 +15,18 @@ type NamespaceService struct {
 }
 
 // Create provides a mock function with given fields: ctx, ns
-func (_m *NamespaceService) Create(ctx context.Context, ns domain.Namespace) (domain.Namespace, error) {
+func (_m *NamespaceService) Create(ctx context.Context, ns namespace.Namespace) (namespace.Namespace, error) {
 	ret := _m.Called(ctx, ns)
 
-	var r0 domain.Namespace
-	if rf, ok := ret.Get(0).(func(context.Context, domain.Namespace) domain.Namespace); ok {
+	var r0 namespace.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, namespace.Namespace) namespace.Namespace); ok {
 		r0 = rf(ctx, ns)
 	} else {
-		r0 = ret.Get(0).(domain.Namespace)
+		r0 = ret.Get(0).(namespace.Namespace)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, domain.Namespace) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, namespace.Namespace) error); ok {
 		r1 = rf(ctx, ns)
 	} else {
 		r1 = ret.Error(1)
@@ -50,14 +50,14 @@ func (_m *NamespaceService) Delete(ctx context.Context, name string) error {
 }
 
 // Get provides a mock function with given fields: ctx, name
-func (_m *NamespaceService) Get(ctx context.Context, name string) (domain.Namespace, error) {
+func (_m *NamespaceService) Get(ctx context.Context, name string) (namespace.Namespace, error) {
 	ret := _m.Called(ctx, name)
 
-	var r0 domain.Namespace
-	if rf, ok := ret.Get(0).(func(context.Context, string) domain.Namespace); ok {
+	var r0 namespace.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, string) namespace.Namespace); ok {
 		r0 = rf(ctx, name)
 	} else {
-		r0 = ret.Get(0).(domain.Namespace)
+		r0 = ret.Get(0).(namespace.Namespace)
 	}
 
 	var r1 error
@@ -94,18 +94,18 @@ func (_m *NamespaceService) List(ctx context.Context) ([]string, error) {
 }
 
 // Update provides a mock function with given fields: ctx, ns
-func (_m *NamespaceService) Update(ctx context.Context, ns domain.Namespace) (domain.Namespace, error) {
+func (_m *NamespaceService) Update(ctx context.Context, ns namespace.Namespace) (namespace.Namespace, error) {
 	ret := _m.Called(ctx, ns)
 
-	var r0 domain.Namespace
-	if rf, ok := ret.Get(0).(func(context.Context, domain.Namespace) domain.Namespace); ok {
+	var r0 namespace.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, namespace.Namespace) namespace.Namespace); ok {
 		r0 = rf(ctx, ns)
 	} else {
-		r0 = ret.Get(0).(domain.Namespace)
+		r0 = ret.Get(0).(namespace.Namespace)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, domain.Namespace) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, namespace.Namespace) error); ok {
 		r1 = rf(ctx, ns)
 	} else {
 		r1 = ret.Error(1)

--- a/mocks/SearchRepository.go
+++ b/mocks/SearchRepository.go
@@ -5,7 +5,7 @@ package mocks
 import (
 	context "context"
 
-	domain "github.com/odpf/stencil/domain"
+	search "github.com/odpf/stencil/core/search"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -15,20 +15,20 @@ type SearchRepository struct {
 }
 
 // Search provides a mock function with given fields: _a0, _a1
-func (_m *SearchRepository) Search(_a0 context.Context, _a1 *domain.SearchRequest) ([]*domain.SearchHits, error) {
+func (_m *SearchRepository) Search(_a0 context.Context, _a1 *search.SearchRequest) ([]*search.SearchHits, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 []*domain.SearchHits
-	if rf, ok := ret.Get(0).(func(context.Context, *domain.SearchRequest) []*domain.SearchHits); ok {
+	var r0 []*search.SearchHits
+	if rf, ok := ret.Get(0).(func(context.Context, *search.SearchRequest) []*search.SearchHits); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*domain.SearchHits)
+			r0 = ret.Get(0).([]*search.SearchHits)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *domain.SearchRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *search.SearchRequest) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
@@ -38,20 +38,20 @@ func (_m *SearchRepository) Search(_a0 context.Context, _a1 *domain.SearchReques
 }
 
 // SearchLatest provides a mock function with given fields: _a0, _a1
-func (_m *SearchRepository) SearchLatest(_a0 context.Context, _a1 *domain.SearchRequest) ([]*domain.SearchHits, error) {
+func (_m *SearchRepository) SearchLatest(_a0 context.Context, _a1 *search.SearchRequest) ([]*search.SearchHits, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 []*domain.SearchHits
-	if rf, ok := ret.Get(0).(func(context.Context, *domain.SearchRequest) []*domain.SearchHits); ok {
+	var r0 []*search.SearchHits
+	if rf, ok := ret.Get(0).(func(context.Context, *search.SearchRequest) []*search.SearchHits); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*domain.SearchHits)
+			r0 = ret.Get(0).([]*search.SearchHits)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *domain.SearchRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *search.SearchRequest) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)

--- a/mocks/SearchService.go
+++ b/mocks/SearchService.go
@@ -5,7 +5,7 @@ package mocks
 import (
 	context "context"
 
-	domain "github.com/odpf/stencil/domain"
+	search "github.com/odpf/stencil/core/search"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -15,20 +15,20 @@ type SearchService struct {
 }
 
 // Search provides a mock function with given fields: _a0, _a1
-func (_m *SearchService) Search(_a0 context.Context, _a1 *domain.SearchRequest) (*domain.SearchResponse, error) {
+func (_m *SearchService) Search(_a0 context.Context, _a1 *search.SearchRequest) (*search.SearchResponse, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 *domain.SearchResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *domain.SearchRequest) *domain.SearchResponse); ok {
+	var r0 *search.SearchResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *search.SearchRequest) *search.SearchResponse); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*domain.SearchResponse)
+			r0 = ret.Get(0).(*search.SearchResponse)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *domain.SearchRequest) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *search.SearchRequest) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)

--- a/mocks/Store.go
+++ b/mocks/Store.go
@@ -6,6 +6,7 @@ import (
 	context "context"
 
 	domain "github.com/odpf/stencil/domain"
+	namespace "github.com/odpf/stencil/core/namespace"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -15,18 +16,18 @@ type Store struct {
 }
 
 // CreateNamespace provides a mock function with given fields: _a0, _a1
-func (_m *Store) CreateNamespace(_a0 context.Context, _a1 domain.Namespace) (domain.Namespace, error) {
+func (_m *Store) CreateNamespace(_a0 context.Context, _a1 namespace.Namespace) (namespace.Namespace, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 domain.Namespace
-	if rf, ok := ret.Get(0).(func(context.Context, domain.Namespace) domain.Namespace); ok {
+	var r0 namespace.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, namespace.Namespace) namespace.Namespace); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		r0 = ret.Get(0).(domain.Namespace)
+		r0 = ret.Get(0).(namespace.Namespace)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, domain.Namespace) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, namespace.Namespace) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
@@ -120,14 +121,14 @@ func (_m *Store) GetLatestVersion(_a0 context.Context, _a1 string, _a2 string) (
 }
 
 // GetNamespace provides a mock function with given fields: _a0, _a1
-func (_m *Store) GetNamespace(_a0 context.Context, _a1 string) (domain.Namespace, error) {
+func (_m *Store) GetNamespace(_a0 context.Context, _a1 string) (namespace.Namespace, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 domain.Namespace
-	if rf, ok := ret.Get(0).(func(context.Context, string) domain.Namespace); ok {
+	var r0 namespace.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, string) namespace.Namespace); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		r0 = ret.Get(0).(domain.Namespace)
+		r0 = ret.Get(0).(namespace.Namespace)
 	}
 
 	var r1 error
@@ -256,18 +257,18 @@ func (_m *Store) ListVersions(_a0 context.Context, _a1 string, _a2 string) ([]in
 }
 
 // UpdateNamespace provides a mock function with given fields: _a0, _a1
-func (_m *Store) UpdateNamespace(_a0 context.Context, _a1 domain.Namespace) (domain.Namespace, error) {
+func (_m *Store) UpdateNamespace(_a0 context.Context, _a1 namespace.Namespace) (namespace.Namespace, error) {
 	ret := _m.Called(_a0, _a1)
 
-	var r0 domain.Namespace
-	if rf, ok := ret.Get(0).(func(context.Context, domain.Namespace) domain.Namespace); ok {
+	var r0 namespace.Namespace
+	if rf, ok := ret.Get(0).(func(context.Context, namespace.Namespace) namespace.Namespace); ok {
 		r0 = rf(_a0, _a1)
 	} else {
-		r0 = ret.Get(0).(domain.Namespace)
+		r0 = ret.Get(0).(namespace.Namespace)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, domain.Namespace) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, namespace.Namespace) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)


### PR DESCRIPTION
As per ODPF golang code conventions, domain objects are better placed in core package itself. As part of this PR we are moving search and namespace into the core packages. 